### PR TITLE
Bootstrap Prometheus pipeline scaffolding

### DIFF
--- a/Next Steps.md
+++ b/Next Steps.md
@@ -1,1 +1,5 @@
-Scaffold and bootstrap the entire project and use correct architecture and directory organisation.
+1. Implement real ingestion connectors and persistence for normalised
+   documents.
+2. Extend retrieval adapters with hybrid search backends and reranking.
+3. Replace in-memory execution and monitoring shims with external system
+   integrations and telemetry exporters.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ See `docs/architecture.md` for sequence diagrams and data contracts,
 Sample datasets, docker-compose profiles, and automation scripts will land in
 future iterations. Track progress in `docs/ROADMAP.md`.
 
+## Bootstrap pipeline
+
+After installing dependencies (`poetry install` or equivalent), run the
+bootstrap pipeline:
+
+```bash
+poetry run python -m prometheus --query "configured"
+```
+
+The command loads `configs/defaults/pipeline.toml`, executes all stages with the
+in-memory adapters, and prints the resulting decision, execution notes, and
+monitoring signal.
+
 ## Development practices
 
 - Keep modules self-contained and communicate via published events.

--- a/common/contracts/base.py
+++ b/common/contracts/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 @dataclass(slots=True, kw_only=True)
@@ -18,7 +18,7 @@ class EvidenceReference:
 
     source_id: str
     uri: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 @dataclass(slots=True, kw_only=True)
@@ -29,8 +29,8 @@ class EventMeta:
     correlation_id: str
     occurred_at: datetime
     schema_version: str = "1.0.0"
-    actor: Optional[str] = None
-    attributes: Dict[str, Any] = field(default_factory=dict)
+    actor: str | None = None
+    attributes: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -38,9 +38,9 @@ class BaseEvent:
     """Base class for all pipeline events."""
 
     meta: EventMeta
-    evidence: List[EvidenceReference] = field(default_factory=list)
+    evidence: list[EvidenceReference] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialise the event to a dictionary for logging or transport."""
 
         return {

--- a/common/contracts/decision.py
+++ b/common/contracts/decision.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
 
 from .base import BaseEvent
 
@@ -15,7 +14,7 @@ class ApprovalTask:
     assignee: str
     due_at: str
     status: str = "pending"
-    notes: List[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -25,6 +24,6 @@ class DecisionRecorded(BaseEvent):
     decision_type: str
     status: str
     rationale: str
-    alternatives: List[str] = field(default_factory=list)
-    approvals: List[ApprovalTask] = field(default_factory=list)
-    policy_checks: Dict[str, str] = field(default_factory=dict)
+    alternatives: list[str] = field(default_factory=list)
+    approvals: list[ApprovalTask] = field(default_factory=list)
+    policy_checks: dict[str, str] = field(default_factory=dict)

--- a/common/contracts/execution.py
+++ b/common/contracts/execution.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
 
 from .base import BaseEvent
 
@@ -16,7 +15,7 @@ class WorkPackage:
     title: str
     status: str
     owner: str
-    metadata: Dict[str, str] = field(default_factory=dict)
+    metadata: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -24,5 +23,5 @@ class ExecutionPlanDispatched(BaseEvent):
     """Event representing execution artefacts pushed downstream."""
 
     sync_target: str
-    work_packages: List[WorkPackage] = field(default_factory=list)
-    notes: List[str] = field(default_factory=list)
+    work_packages: list[WorkPackage] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)

--- a/common/contracts/ingestion.py
+++ b/common/contracts/ingestion.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
 
 from .base import BaseEvent
 
@@ -24,6 +23,6 @@ class IngestionNormalised(BaseEvent):
 
     source_system: str
     canonical_uri: str
-    provenance: Dict[str, str] = field(default_factory=dict)
-    pii_redactions: List[str] = field(default_factory=list)
-    attachments: List[AttachmentManifest] = field(default_factory=list)
+    provenance: dict[str, str] = field(default_factory=dict)
+    pii_redactions: list[str] = field(default_factory=list)
+    attachments: list[AttachmentManifest] = field(default_factory=list)

--- a/common/contracts/monitoring.py
+++ b/common/contracts/monitoring.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
 
 from .base import BaseEvent
 
@@ -14,7 +13,7 @@ class MetricSample:
 
     name: str
     value: float
-    labels: Dict[str, str] = field(default_factory=dict)
+    labels: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -23,5 +22,5 @@ class MonitoringSignal(BaseEvent):
 
     signal_type: str
     description: str
-    metrics: List[MetricSample] = field(default_factory=list)
-    incidents: List[str] = field(default_factory=list)
+    metrics: list[MetricSample] = field(default_factory=list)
+    incidents: list[str] = field(default_factory=list)

--- a/common/contracts/reasoning.py
+++ b/common/contracts/reasoning.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
 
 from .base import BaseEvent
 
@@ -14,7 +13,7 @@ class Insight:
 
     text: str
     confidence: float
-    assumptions: List[str] = field(default_factory=list)
+    assumptions: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -22,7 +21,7 @@ class ReasoningAnalysisProposed(BaseEvent):
     """Proposed analysis forwarded to the decision stage."""
 
     summary: str
-    recommended_actions: List[str] = field(default_factory=list)
-    insights: List[Insight] = field(default_factory=list)
-    unresolved_questions: List[str] = field(default_factory=list)
-    metadata: Dict[str, str] = field(default_factory=dict)
+    recommended_actions: list[str] = field(default_factory=list)
+    insights: list[Insight] = field(default_factory=list)
+    unresolved_questions: list[str] = field(default_factory=list)
+    metadata: dict[str, str] = field(default_factory=dict)

--- a/common/contracts/retrieval.py
+++ b/common/contracts/retrieval.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
 
 from .base import BaseEvent
 
@@ -15,7 +14,7 @@ class RetrievedPassage:
     source_id: str
     snippet: str
     score: float
-    metadata: Dict[str, str] = field(default_factory=dict)
+    metadata: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -23,5 +22,5 @@ class RetrievalContextBundle(BaseEvent):
     """Bundle of evidence provided to the reasoning stage."""
 
     query: str
-    strategy: Dict[str, str] = field(default_factory=dict)
-    passages: List[RetrievedPassage] = field(default_factory=list)
+    strategy: dict[str, str] = field(default_factory=dict)
+    passages: list[RetrievedPassage] = field(default_factory=list)

--- a/common/events.py
+++ b/common/events.py
@@ -1,0 +1,86 @@
+"""Event system scaffolding for the Prometheus pipeline."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable, MutableMapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, TypeVar
+
+from .contracts import BaseEvent, EventMeta
+
+EventT = TypeVar("EventT", bound=BaseEvent)
+
+
+@dataclass(slots=True)
+class EventFactory:
+    """Produce :class:`EventMeta` instances with shared correlation IDs."""
+
+    correlation_id: str
+    schema_version: str = "1.0.0"
+
+    def create_meta(
+        self,
+        *,
+        event_name: str,
+        actor: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> EventMeta:
+        """Return a fresh event envelope for the provided ``event_name``."""
+
+        attrs: dict[str, Any] = {"event_name": event_name}
+        if attributes:
+            attrs.update(attributes)
+        return EventMeta(
+            event_id=self._uuid(),
+            correlation_id=self.correlation_id,
+            occurred_at=datetime.now(UTC),
+            schema_version=self.schema_version,
+            actor=actor,
+            attributes=attrs,
+        )
+
+    @staticmethod
+    def _uuid() -> str:
+        from uuid import uuid4
+
+        return str(uuid4())
+
+
+class EventBus:
+    """Synchronous pub/sub broker used while bootstrapping the pipeline."""
+
+    def __init__(self) -> None:
+        self._subscribers: MutableMapping[
+            type[BaseEvent], list[Callable[[BaseEvent], None]]
+        ] = defaultdict(list)
+        self._history: list[BaseEvent] = []
+
+    def subscribe(
+        self, event_type: type[EventT], handler: Callable[[EventT], None]
+    ) -> None:
+        """Register ``handler`` for the given ``event_type``."""
+
+        def _wrapper(event: BaseEvent) -> None:
+            handler(event)  # type: ignore[arg-type]
+
+        self._subscribers[event_type].append(_wrapper)
+
+    def publish(self, event: EventT) -> None:
+        """Dispatch ``event`` to matching subscribers and record history."""
+
+        self._history.append(event)
+        for registered_type, handlers in list(self._subscribers.items()):
+            if isinstance(event, registered_type):
+                for handler in handlers:
+                    handler(event)
+
+    def replay(self) -> Iterable[BaseEvent]:
+        """Return an iterator over all published events."""
+
+        return iter(self._history)
+
+
+__all__ = ["EventBus", "EventFactory"]
+

--- a/configs/README.md
+++ b/configs/README.md
@@ -5,8 +5,9 @@ deployment profile described in the `Promethus Brief.md`.
 
 ## Configuration layers
 
-1. **Defaults (`configs/defaults/` TBD).** Baseline settings shared across
-   laptop, self-hosted, and SaaS deployments.
+1. **Defaults (`configs/defaults/`).** Baseline settings shared across laptop,
+   self-hosted, and SaaS deployments. `pipeline.toml` captures the bootstrap
+   pipeline wiring used by the CLI entrypoint.
 2. **Environment overrides (`configs/env/`).** Per-environment values (dev,
    staging, prod) that tune feature flags, SLO thresholds, and telemetry sinks.
 3. **Secrets (`.env`, secret managers).** API keys, credentials, and signing

--- a/configs/defaults/pipeline.toml
+++ b/configs/defaults/pipeline.toml
@@ -1,0 +1,20 @@
+[ingestion]
+sources = ["memory://prometheus-brief"]
+
+[retrieval]
+strategy = "in-memory"
+max_results = 10
+
+[reasoning]
+planner = "sequential"
+max_tokens = 2048
+
+[decision]
+policy_engine = "policy.simple"
+
+[execution]
+sync_target = "in-memory"
+
+[monitoring]
+sample_rate = 1.0
+

--- a/decision/service.py
+++ b/decision/service.py
@@ -29,4 +29,21 @@ class DecisionService:
     ) -> DecisionRecorded:
         """Run policy evaluation and return a recorded decision."""
 
-        raise NotImplementedError("Decision evaluation has not been implemented")
+        status = "approved" if proposal.recommended_actions else "needs_review"
+        rationale = proposal.summary
+        alternatives = [
+            "Manual review",
+            "Request additional evidence",
+        ]
+        policy_checks = {
+            "engine": self._config.policy_engine,
+            "insight_count": str(len(proposal.insights)),
+        }
+        return DecisionRecorded(
+            meta=meta,
+            decision_type="automated",
+            status=status,
+            rationale=rationale,
+            alternatives=alternatives,
+            policy_checks=policy_checks,
+        )

--- a/prometheus/__init__.py
+++ b/prometheus/__init__.py
@@ -1,0 +1,12 @@
+"""Top-level package for Prometheus orchestration utilities."""
+
+from .config import PrometheusConfig
+from .pipeline import PipelineResult, PrometheusOrchestrator, build_orchestrator
+
+__all__ = [
+    "PrometheusConfig",
+    "PipelineResult",
+    "PrometheusOrchestrator",
+    "build_orchestrator",
+]
+

--- a/prometheus/__main__.py
+++ b/prometheus/__main__.py
@@ -1,0 +1,38 @@
+"""CLI entrypoint for the Prometheus bootstrap pipeline."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .config import PrometheusConfig
+from .pipeline import build_orchestrator
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default="configs/defaults/pipeline.toml",
+        help="Path to the pipeline configuration file.",
+    )
+    parser.add_argument(
+        "--query",
+        default="Summarise configured sources",
+        help="Query to send through the pipeline.",
+    )
+    args = parser.parse_args(argv)
+
+    config = PrometheusConfig.load(Path(args.config))
+    orchestrator = build_orchestrator(config)
+    result = orchestrator.run(args.query)
+
+    print(f"Decision status: {result.decision.status}")
+    print(f"Execution notes: {result.execution.notes}")
+    print(f"Monitoring signal: {result.monitoring.description}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entrypoint
+    raise SystemExit(main())
+

--- a/prometheus/config.py
+++ b/prometheus/config.py
@@ -1,0 +1,58 @@
+"""Configuration loader for Prometheus pipeline bootstrap."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from decision.service import DecisionConfig
+from execution.service import ExecutionConfig
+from ingestion.service import IngestionConfig
+from monitoring.service import MonitoringConfig
+from reasoning.service import ReasoningConfig
+from retrieval.service import RetrievalConfig
+
+
+@dataclass(slots=True, kw_only=True)
+class PrometheusConfig:
+    """Container for stage configuration objects."""
+
+    ingestion: IngestionConfig
+    retrieval: RetrievalConfig
+    reasoning: ReasoningConfig
+    decision: DecisionConfig
+    execution: ExecutionConfig
+    monitoring: MonitoringConfig
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> PrometheusConfig:
+        """Construct configuration from a mapping structure."""
+
+        return cls(
+            ingestion=IngestionConfig(**data["ingestion"]),
+            retrieval=RetrievalConfig(**data["retrieval"]),
+            reasoning=ReasoningConfig(**data["reasoning"]),
+            decision=DecisionConfig(**data["decision"]),
+            execution=ExecutionConfig(**data["execution"]),
+            monitoring=MonitoringConfig(**data["monitoring"]),
+        )
+
+    @classmethod
+    def load(cls, path: Path) -> PrometheusConfig:
+        """Load configuration from a TOML or JSON document."""
+
+        suffix = path.suffix.lower()
+        if suffix == ".toml":
+            import tomllib
+
+            payload = tomllib.loads(path.read_text(encoding="utf-8"))
+        elif suffix == ".json":
+            import json
+
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        else:
+            raise ValueError(f"Unsupported config format: {path}")
+        return cls.from_mapping(payload)
+

--- a/prometheus/pipeline.py
+++ b/prometheus/pipeline.py
@@ -1,0 +1,179 @@
+"""Pipeline orchestration for Prometheus."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+from common.contracts import (
+    DecisionRecorded,
+    ExecutionPlanDispatched,
+    IngestionNormalised,
+    MonitoringSignal,
+    ReasoningAnalysisProposed,
+    RetrievalContextBundle,
+)
+from common.events import EventBus, EventFactory
+from decision.service import DecisionService
+from execution.service import ExecutionAdapter, ExecutionService
+from ingestion.service import IngestionService
+from monitoring.service import MonitoringService, SignalCollector
+from reasoning.service import ReasoningService
+from retrieval.service import InMemoryRetriever, RetrievalService
+
+from .config import PrometheusConfig
+from .plugins import AuditTrailPlugin, PipelinePlugin, PluginRegistry
+
+
+@dataclass(slots=True)
+class PipelineResult:
+    """Structured result of a pipeline execution."""
+
+    ingestion: list[IngestionNormalised]
+    retrieval: RetrievalContextBundle
+    reasoning: ReasoningAnalysisProposed
+    decision: DecisionRecorded
+    execution: ExecutionPlanDispatched
+    monitoring: MonitoringSignal
+
+
+class PrometheusOrchestrator:
+    """Coordinates the pipeline stages for a single run."""
+
+    def __init__(
+        self,
+        config: PrometheusConfig,
+        *,
+        bus: EventBus,
+        ingestion: IngestionService,
+        retrieval: RetrievalService,
+        reasoning: ReasoningService,
+        decision: DecisionService,
+        execution: ExecutionService,
+        monitoring: MonitoringService,
+        plugins: Iterable[PipelinePlugin] | None = None,
+    ) -> None:
+        self._config = config
+        self._bus = bus
+        self._ingestion = ingestion
+        self._retrieval = retrieval
+        self._reasoning = reasoning
+        self._decision = decision
+        self._execution = execution
+        self._monitoring = monitoring
+        self.registry = PluginRegistry(bus)
+        self.bus = bus
+        self.execution_adapter: ExecutionAdapter | None = None
+        self.signal_collectors: list[SignalCollector] = []
+        for plugin in plugins or ():
+            self.registry.register(plugin)
+
+    def run(self, query: str, *, actor: str | None = None) -> PipelineResult:
+        """Execute the end-to-end pipeline for a query."""
+
+        factory = EventFactory(correlation_id=self._new_correlation())
+        evidence = list(self._ingestion.collect())
+        normalised = self._ingestion.normalise(evidence, factory)
+        for event in normalised:
+            self._bus.publish(event)
+
+        self._retrieval.ingest(normalised)
+        retrieval_meta = factory.create_meta(
+            event_name="retrieval.context", actor=actor
+        )
+        context = self._retrieval.build_context(query, retrieval_meta)
+        self._bus.publish(context)
+
+        reasoning_meta = factory.create_meta(
+            event_name="reasoning.analysis", actor=actor
+        )
+        analysis = self._reasoning.analyse(context, reasoning_meta)
+        self._bus.publish(analysis)
+
+        decision_meta = factory.create_meta(
+            event_name="decision.recorded", actor=actor
+        )
+        decision = self._decision.evaluate(analysis, decision_meta)
+        self._bus.publish(decision)
+
+        execution_meta = factory.create_meta(
+            event_name="execution.dispatched", actor=actor
+        )
+        execution_plan = self._execution.sync(decision, execution_meta)
+        self._bus.publish(execution_plan)
+
+        monitoring_meta = factory.create_meta(
+            event_name="monitoring.signal", actor=actor
+        )
+        signal = self._monitoring.build_signal(decision, monitoring_meta)
+        self._monitoring.emit(signal)
+        self._bus.publish(signal)
+
+        return PipelineResult(
+            ingestion=normalised,
+            retrieval=context,
+            reasoning=analysis,
+            decision=decision,
+            execution=execution_plan,
+            monitoring=signal,
+        )
+
+    def _new_correlation(self) -> str:
+        from uuid import uuid4
+
+        return str(uuid4())
+
+
+def build_orchestrator(config: PrometheusConfig) -> PrometheusOrchestrator:
+    """Create a default orchestrator wired with in-memory adapters."""
+
+    bus = EventBus()
+    ingestion = IngestionService(config.ingestion)
+    retriever = InMemoryRetriever()
+    retrieval = RetrievalService(config.retrieval, retriever)
+    reasoning = ReasoningService(config.reasoning)
+    decision = DecisionService(config.decision)
+    execution_adapter = _InMemoryExecutionAdapter()
+    execution = ExecutionService(config.execution, execution_adapter)
+    collector = _InMemorySignalCollector()
+    monitoring = MonitoringService(config.monitoring, [collector])
+    orchestrator = PrometheusOrchestrator(
+        config,
+        bus=bus,
+        ingestion=ingestion,
+        retrieval=retrieval,
+        reasoning=reasoning,
+        decision=decision,
+        execution=execution,
+        monitoring=monitoring,
+        plugins=[AuditTrailPlugin()],
+    )
+    orchestrator.execution_adapter = execution_adapter
+    orchestrator.signal_collectors = [collector]
+    return orchestrator
+
+
+@dataclass(slots=True)
+class _InMemoryExecutionAdapter(ExecutionAdapter):
+    """Execution adapter that records dispatched notes."""
+
+    notes: list[str] = field(default_factory=list)
+
+    def dispatch(self, decision: DecisionRecorded) -> Iterable[str]:
+        note = (
+            f"Dispatched decision {decision.meta.event_id} to"
+            f" {decision.decision_type}"
+        )
+        self.notes.append(note)
+        yield note
+
+
+@dataclass(slots=True)
+class _InMemorySignalCollector(SignalCollector):
+    """Collector storing monitoring signals for later inspection."""
+
+    signals: list[MonitoringSignal] = field(default_factory=list)
+
+    def publish(self, signal: MonitoringSignal) -> None:
+        self.signals.append(signal)
+

--- a/prometheus/plugins.py
+++ b/prometheus/plugins.py
@@ -1,0 +1,55 @@
+"""Plugin scaffolding for Prometheus."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from common.contracts import BaseEvent
+from common.events import EventBus
+
+
+class PipelinePlugin(Protocol):
+    """Interface for pipeline plugins."""
+
+    name: str
+
+    def setup(self, bus: EventBus) -> None:
+        """Register event handlers on the provided bus."""
+
+
+@dataclass(slots=True)
+class PluginRegistry:
+    """Tracks registered plugins and exposes their metadata."""
+
+    bus: EventBus
+    _plugins: list[PipelinePlugin] = field(default_factory=list)
+
+    def register(self, plugin: PipelinePlugin) -> None:
+        plugin.setup(self.bus)
+        self._plugins.append(plugin)
+
+    def names(self) -> Iterable[str]:
+        return (plugin.name for plugin in self._plugins)
+
+    def plugins(self) -> Iterable[PipelinePlugin]:
+        return tuple(self._plugins)
+
+
+@dataclass(slots=True)
+class AuditTrailPlugin:
+    """Captures published events for compliance and debugging."""
+
+    name: str = "audit_trail"
+    events: list[BaseEvent] = field(default_factory=list)
+
+    def setup(self, bus: EventBus) -> None:  # pragma: no cover - trivial wiring
+        def _record(event: BaseEvent) -> None:
+            self.events.append(event)
+
+        bus.subscribe(BaseEvent, _record)
+
+
+__all__ = ["AuditTrailPlugin", "PipelinePlugin", "PluginRegistry"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "prometheus-os"
+version = "0.1.0"
+description = "Prometheus Strategy OS bootstrap"
+authors = ["Prometheus Contributors <oss@example.com>"]
+readme = "README.md"
+packages = [
+  { include = "prometheus" },
+  { include = "common" },
+  { include = "ingestion" },
+  { include = "retrieval" },
+  { include = "reasoning" },
+  { include = "decision" },
+  { include = "execution" },
+  { include = "monitoring" },
+]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+ruff = "^0.4.0"
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+extend-select = ["B", "I", "UP"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+addopts = "-q"
+testpaths = ["tests"]
+

--- a/retrieval/service.py
+++ b/retrieval/service.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
-from common.contracts import EventMeta, RetrievalContextBundle, RetrievedPassage
+from common.contracts import (
+    EventMeta,
+    IngestionNormalised,
+    RetrievalContextBundle,
+    RetrievedPassage,
+)
 
 
 class Retriever(Protocol):
@@ -26,12 +31,24 @@ class RetrievalConfig:
     max_results: int = 20
 
 
+@runtime_checkable
+class _SupportsIngest(Protocol):
+    def ingest(self, documents: Iterable[IngestionNormalised]) -> None:
+        ...
+
+
 class RetrievalService:
     """Coordinates lexical/vector retrievers and reranking."""
 
     def __init__(self, config: RetrievalConfig, retriever: Retriever) -> None:
         self._config = config
         self._retriever = retriever
+
+    def ingest(self, documents: Iterable[IngestionNormalised]) -> None:
+        """Pass documents to the underlying retriever when supported."""
+
+        if isinstance(self._retriever, _SupportsIngest):
+            self._retriever.ingest(documents)
 
     def build_context(self, query: str, meta: EventMeta) -> RetrievalContextBundle:
         """Produce the context bundle forwarded to reasoning."""
@@ -43,3 +60,27 @@ class RetrievalService:
             strategy={"name": self._config.strategy},
             passages=passages,
         )
+
+
+class InMemoryRetriever:
+    """Simple retriever used for bootstrap and testing flows."""
+
+    def __init__(self) -> None:
+        self._passages: list[RetrievedPassage] = []
+
+    def ingest(self, documents: Iterable[IngestionNormalised]) -> None:
+        self._passages = [
+            RetrievedPassage(
+                source_id=document.source_system,
+                snippet=document.provenance.get("description", document.canonical_uri),
+                score=1.0,
+                metadata={"uri": document.canonical_uri},
+            )
+            for document in documents
+        ]
+
+    def retrieve(self, query: str) -> Iterable[RetrievedPassage]:
+        lowered = query.lower()
+        for passage in self._passages:
+            if not lowered or lowered in passage.snippet.lower():
+                yield passage

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,0 +1,34 @@
+"""Bootstrap tests for the Prometheus pipeline."""
+
+from __future__ import annotations
+
+from prometheus import PrometheusConfig, build_orchestrator
+
+
+def _config() -> PrometheusConfig:
+    return PrometheusConfig.from_mapping(
+        {
+            "ingestion": {"sources": ["memory://test-source"]},
+            "retrieval": {"strategy": "in-memory", "max_results": 5},
+            "reasoning": {"planner": "sequential", "max_tokens": 512},
+            "decision": {"policy_engine": "policy.simple"},
+            "execution": {"sync_target": "in-memory"},
+            "monitoring": {"sample_rate": 1.0},
+        }
+    )
+
+
+def test_pipeline_emits_events_and_records_audit_trail() -> None:
+    orchestrator = build_orchestrator(_config())
+    result = orchestrator.run("configured")
+
+    assert result.decision.status == "approved"
+    assert orchestrator.execution_adapter is not None
+    assert orchestrator.execution_adapter.notes
+    assert orchestrator.signal_collectors[0].signals
+
+    events = list(orchestrator.bus.replay())
+    assert len(events) >= 5
+
+    audit_plugin = next(iter(orchestrator.registry.plugins()))
+    assert audit_plugin.events  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- add project packaging, event bus, orchestrator wiring, plugin registry, and CLI to run the bootstrap pipeline
- flesh out stage services, config loader, and default configuration to produce end-to-end events
- document the bootstrap flow, add a pipeline smoke test, and record follow-up next steps

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d7b202b3208330a81d238b4da75c58